### PR TITLE
Allow overriding completions timeout.

### DIFF
--- a/docs/cli-options.md
+++ b/docs/cli-options.md
@@ -57,6 +57,7 @@ These options control the chat interaction:
 | `--output-chat-history <file>` | Save chat history to a JSONL file |
 | `--output-trajectory <file>` | Save chat history in a more readable trajectory format |
 | `--trim-token-target <n>` | Set a target token count for trimming chat history when it gets too large |
+| `--chat-completion-timeout <n>` | Set a timeout in seconds for chat completion API calls |
 
 ## Provider Selection Options
 
@@ -161,6 +162,16 @@ chatx --trim-token-target 120000 --input-chat-history "long-conversation.jsonl" 
 ```
 
 This will automatically trim tool call content when the history approaches the specified token target.
+
+### Setting Completion Timeout
+
+If you're experiencing timeouts with API calls:
+
+```bash
+chatx --chat-completion-timeout 120 --input "Please write a comprehensive analysis of this long text..."
+```
+
+This sets a 120-second timeout for chat completion API calls, useful for complex queries that take longer to process.
 
 ### Using Different Providers
 

--- a/docs/configuration-features.md
+++ b/docs/configuration-features.md
@@ -96,6 +96,9 @@ Config files store persistent settings for the application.
 # Set a configuration value
 chatx config set default-model gpt-4o
 
+# Set a timeout for chat completions (in seconds)
+chatx config set App.ChatCompletionTimeout 120
+
 # View configuration 
 chatx config list
 ```

--- a/src/ChatClient/ChatClientFactory.cs
+++ b/src/ChatClient/ChatClientFactory.cs
@@ -222,7 +222,7 @@ public static class ChatClientFactory
         {
             int timeoutSeconds = timeoutSetting.AsInt();
             ConsoleHelpers.WriteDebugLine($"Setting chat completion timeout to {timeoutSeconds} seconds");
-            options.Transport.RequestTimeout = TimeSpan.FromSeconds(timeoutSeconds);
+            options.NetworkTimeout = TimeSpan.FromSeconds(timeoutSeconds);
         }
         
         return options;

--- a/src/ChatClient/ChatClientFactory.cs
+++ b/src/ChatClient/ChatClientFactory.cs
@@ -3,6 +3,7 @@ using Azure.AI.OpenAI;
 using Microsoft.Extensions.AI;
 using OpenAI;
 using OpenAI.Chat;
+using System;
 using System.ClientModel;
 using System.ClientModel.Primitives;
 
@@ -214,6 +215,16 @@ public static class ChatClientFactory
         options.AddPolicy(new FixNullFunctionArgsPolicy(), PipelinePosition.PerCall);
         options.AddPolicy(new LogTrafficEventPolicy(), PipelinePosition.PerCall);
         options.RetryPolicy = new ClientRetryPolicy(maxRetries: 10);
+        
+        // Apply timeout if configured
+        var timeoutSetting = ConfigStore.Instance.GetFromAnyScope(KnownSettings.AppChatCompletionTimeout);
+        if (timeoutSetting.AsInt() > 0)
+        {
+            int timeoutSeconds = timeoutSetting.AsInt();
+            ConsoleHelpers.WriteDebugLine($"Setting chat completion timeout to {timeoutSeconds} seconds");
+            options.Transport.RequestTimeout = TimeSpan.FromSeconds(timeoutSeconds);
+        }
+        
         return options;
     }
 }

--- a/src/Configuration/KnownSettings.cs
+++ b/src/Configuration/KnownSettings.cs
@@ -34,6 +34,7 @@ public static class KnownSettings
     public const string AppPreferredProvider = "App.PreferredProvider";
     public const string AppAutoSaveChatHistory = "App.AutoSaveChatHistory";
     public const string AppAutoSaveTrajectory = "App.AutoSaveTrajectory";
+    public const string AppChatCompletionTimeout = "App.ChatCompletionTimeout";
     
     #endregion
     
@@ -89,7 +90,8 @@ public static class KnownSettings
         { AppMaxTokens, "APP_MAX_TOKENS" },
         { AppPreferredProvider, "CHATX_PREFERRED_PROVIDER" },
         { AppAutoSaveChatHistory, "CHATX_AUTO_SAVE_CHAT_HISTORY" },
-        { AppAutoSaveTrajectory, "CHATX_AUTO_SAVE_TRAJECTORY" }
+        { AppAutoSaveTrajectory, "CHATX_AUTO_SAVE_TRAJECTORY" },
+        { AppChatCompletionTimeout, "CHATX_CHAT_COMPLETION_TIMEOUT" }
     };
     
     /// <summary>
@@ -119,7 +121,8 @@ public static class KnownSettings
         // Application settings
         { AppMaxTokens, "--max-tokens" },
         { AppAutoSaveChatHistory, "--auto-save-chat-history" },
-        { AppAutoSaveTrajectory, "--auto-save-trajectory" }
+        { AppAutoSaveTrajectory, "--auto-save-trajectory" },
+        { AppChatCompletionTimeout, "--chat-completion-timeout" }
     };
     
     /// <summary>
@@ -183,7 +186,8 @@ public static class KnownSettings
         AppMaxTokens,
         AppPreferredProvider,
         AppAutoSaveChatHistory,
-        AppAutoSaveTrajectory
+        AppAutoSaveTrajectory,
+        AppChatCompletionTimeout
     };
     
     #endregion

--- a/src/assets/help/options.txt
+++ b/src/assets/help/options.txt
@@ -73,6 +73,7 @@ USAGE: chatx [...]
     --debug                               Turn on diagnostics/debug outputs
     --quiet                               Turn off all but the most critical console outputs
     --verbose                             Turn on additional diagnostics/debug outputs
+    --chat-completion-timeout SECONDS     Set a timeout in seconds for chat completion API calls
 
 SEE ALSO
 


### PR DESCRIPTION
Some long running completions calls can take longer than the default 120s, allow overriding to resolve.